### PR TITLE
Bugfix: get Swagger to include all API endpoints

### DIFF
--- a/library/src/main/java/no/ntnu/library/LibraryApplication.java
+++ b/library/src/main/java/no/ntnu/library/LibraryApplication.java
@@ -26,7 +26,7 @@ public class LibraryApplication {
 	public Docket swaggerConfiguration() {
 		return new Docket(DocumentationType.SWAGGER_2)
 				.select()
-				.paths(PathSelectors.ant("/*"))
+				.paths(PathSelectors.ant("/**"))
 				.apis(RequestHandlerSelectors.basePackage("no.ntnu"))
 				.build()
 				.apiInfo(apiDetails());


### PR DESCRIPTION
The bug was that Ant path matcher had filter "/*" which matches only /books and /authors, but does not match /books/id and /authors/id
Use /** in path matching to include also sub-paths with multiple slashes